### PR TITLE
Reformat the Ruby code and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 ### Description
 
-> Warning: master may be broken whilst this repo is upgraded for k/v v2 and newer Vault version upgrades! Please use the 0.1.0 tagged release in the meantime. This message will be removed and a 1.0.0 breaking release will be tagged on the Forge in the future.
+This is a back end function for Hiera 5 that allows lookup to be sourced from Hashicorp's Vault or its open-source fork OpenBao.
 
-This is a back end function for Hiera 5 that allows lookup to be sourced from Hashicorp's Vault.
-
-[Vault](https://vaultproject.io) secures, stores, and tightly controls access to tokens, passwords, certificates, API keys, and other secrets in modern computing. Vault handles leasing, key revocation, key rolling, and auditing. Vault presents a unified API to access multiple backends: HSMs, AWS IAM, SQL databases, raw key/value, and more.
+[Vault](https://developer.hashicorp.com/vault) and [OpenBao](https://openbao.org/) secure, store, and tightly control access to tokens, passwords, certificates, API keys, and other secrets in modern computing. Vault/OpenBao handle leasing, key revocation, key rolling, and auditing. Vault/OpenBao present a unified API to access multiple backends: HSMs, AWS IAM, SQL databases, raw key/value, and more.
 
 For an example repo of it in action, check out the [hashicorp/webinar-vault-hiera-puppet](https://github.com/hashicorp/webinar-vault-hiera-puppet) repo and webinar ['How to Use HashiCorp Vault with Hiera 5 for Secret Management with Puppet'](https://www.hashicorp.com/resources/hashicorp-vault-with-puppet-hiera-5-for-secret-management)
 
@@ -19,7 +17,7 @@ For an example repo of it in action, check out the [hashicorp/webinar-vault-hier
 The `vault` and `debouncer` gems must be installed and loadable from Puppet
 
 ```
-# /opt/puppetlabs/puppet/bin/gem install --user-install vault
+# /opt/puppetlabs/puppet/bin/gem install --user-install vault
 # /opt/puppetlabs/puppet/bin/gem install --user-install debouncer
 # puppetserver gem install vault
 # puppetserver gem install debouncer
@@ -83,19 +81,19 @@ This will avaliable on the forge, and installable with the module command:
 You can also download the module directly:
 
 ```shell
-git clone https://github.com/petems/petems-hiera_vault /etc/puppetlabs/code/environments/production/modules/hiera_vault
+git clone https://github.com/voxpupuli/puppet-hiera_vault /etc/puppetlabs/code/environments/production/modules/hiera_vault
 ```
 
 Or add it to your Puppetfile
 
 ```ruby
 mod 'hiera_vault',
-  :git => 'https://github.com/petems/petems-hiera_vault'
+  :git => 'https://github.com/voxpupuli/puppet-hiera_vault'
 ```
 
 ### Hiera Configuration
 
-See [The official Puppet documentation](https://docs.puppet.com/puppet/4.9/hiera_intro.html) for more details on configuring Hiera 5.
+See [The official Puppet documentation](https://www.puppet.com/docs/puppet/7/hiera_intro) for more details on configuring Hiera 5.
 
 The following is an example Hiera 5 hiera.yaml configuration for use with hiera-vault
 
@@ -124,21 +122,37 @@ hierarchy:
           - common
 ```
 
-The following mandatory Hiera 5 options must be set for each level of the hierarchy.
+The following Hiera 5 options must be set for each level of the hierarchy.
 
-`name`: A human readable name for the lookup
-
-`lookup_key`: This option must be set to `hiera_vault`
+| Option       | Description
+|--------------|---
+| `name`       | A human readable name for the lookup
+| `lookup_key` | This option must be set to `hiera_vault`
 
 The following are optional configuration parameters supported in the `options` hash of the Hiera 5 config
 
-`address`: The address of the Vault server or Vault Agent, also read as `ENV["VAULT_ADDR"]`. Note: Not currently compatible with unix domain sockets - you must use `http://` or `https://`
+| Parameter                | Description
+|--------------------------|------------
+| `address`                | The address of the Vault server or Vault Agent, also read as `ENV["VAULT_ADDR"]`. Note: Not currently compatible with unix domain sockets - you must use `http://` or `https://`
+| `token`                  | The token to authenticate with Vault, also read as `ENV["VAULT_TOKEN"]` or a full path to the file with the token (eg. `/etc/vault_token.txt`). When bootstrapping, you can set this token as `IGNORE-VAULT` and the backend will be stubbed, which can be useful when bootstrapping.
+| `cache_for`              | How long to cache a given key in seconds. If not present the response will never be cached.
+| `confine_to_keys`        | Only use this backend if the key matches one of the regexes in the array, to avoid constantly reaching out to Vault for every parameter lookup
+| `continue_if_not_found`  | Allow hiera to look beyond vault if the value is not found
+| `strip_from_keys`        | Patterns to strip from keys before lookup
+| `default_field`          | The default field within data to return. If not present, the lookup will be the full contents of the secret data.
+| `default_field_behavior` | seting to `ignore` or undefined will **always** retugn the value of `default_field` key from the object retrieved from Vault, even if other keys exist. If set to `only`, it **returns a single string if there's one and only one field named after `default_field` in Vault**, otherwise it returns a Hash of all found keys and values.
+| `default_field_parse`    | setting to `string` or undefined will parse the default field as string, `json` will parse it as JSON data
+| `mounts`                 | The list of mounts you want to do lookups against. This is treated as the backend hiearchy for lookup. It is recomended you use [Trusted Facts](https://puppet.com/docs/puppet/5.3/lang_facts_and_builtin_vars.html#trusted-facts) within the hierachy to ensure lookups are restricted to the correct hierachy points. See [Mounts](#mounts).
+| `ssl_verify`             | Specify whether to verify SSL certificates (default: `true`)
+| `ssl_pem_file`           | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) configuration of the TLS PEM file
+| `ssl_ca_cert`            | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) configuration of the certificate authority
+| `ssl_ca_path`            | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) CA path
+| `ssl_ciphers`            | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) configuration of TLS ciphers
+| `strict_mode`            | When enabled, the lookup function fail in case of http errors when looking up a secret.
+| `v1_lookup`              | whether to lookup within kv v1 hierarchy (default `true`) - disable if you only use kv v2 :) See [Less lookups](#less-lookups).
+| `v2_guess_mount`         | whether to try to guess mount for KV v2 (default `true`) - add `data` after your mount and disable to minimize amount of misses. See [Less lookups](#less-lookups).
 
-`token`: The token to authenticate with Vault, also read as `ENV["VAULT_TOKEN"]` or a full path to the file with the token (eg. `/etc/vault_token.txt`). When bootstrapping, you can set this token as `IGNORE-VAULT` and the backend will be stubbed, which can be useful when bootstrapping.
-
-`cache_for`: How long to cache a given key in seconds. If not present the response will never be cached.
-
-`confine_to_keys:`: Only use this backend if the key matches one of the regexes in the array, to avoid constantly reaching out to Vault for every parameter lookup
+#### Example use of `confine_to_keys`
 
 ```yaml
 confine_to_keys:
@@ -146,24 +160,61 @@ confine_to_keys:
   - "apache::.*"
 ```
 
-`strip_from_keys`: Patterns to strip from keys before lookup
-
+#### Example use of `strip_from_keys`
 ```yaml
 strip_from_keys:
   - "vault:"
 ```
 
-`default_field:`: The default field within data to return. If not present, the lookup will be the full contents of the secret data.
+#### Example use of `default_field_behavior` set to `only`
 
-`mounts:`: The list of mounts you want to do lookups against. This is treated as the backend hiearchy for lookup. It is recomended you use [Trusted Facts](https://puppet.com/docs/puppet/5.3/lang_facts_and_builtin_vars.html#trusted-facts) within the hierachy to ensure lookups are restricted to the correct hierachy points. See [Mounts](#mounts).
+`hiera.yaml` for Vault KV2, without guess mounting. Default value named `value`.
 
-`:ssl_verify`: Specify whether to verify SSL certificates (default: true)
+```yaml
+# (...)
+hierarchy:
+- lookup_key: hiera_vault
+  name: Search for hiera data in Vault
+  options:
+    v2_guess_mount: false
+    v1_lookup: false
+    confine_to_keys:
+    - ^vault_.*
+    default_field: value
+    default_field_behavior: only
+    ssl_verify: false
+    # Token is loaded from the environment variable
+    address: https://vault.foobar.com:8200
+    mounts:
+      secrets/data:
+      - puppet/common
+      - certificates
+    ssl_verify: false
+    strip_from_keys:
+    - ^vault_
+version: 5
+# (...)
+```
 
-`:strict_mode`: When enabled, the lookup function fail in case of http errors when looking up a secret.
+Now, assuming Vault contains two objects:
+- http://vault.foobar.com:8200/secrets/data/puppet/common/simple_string with keys
+  - `value` (e.g. a simple string value)
+- http://vault.foobar.com:8200/secrets/data/certificates/certificate_domain.net with keys
+  - `tls.crt` (e.g. the public part of a x509 certifiate)
+  - `tls.key` (e.g. the certifiate private key)
+  - `value` (any arbitrary string)
 
-`v1_lookup`: whether to lookup within kv v1 hierarchy (default `true`) - disable if you only use kv v2 :) See [Less lookups](#less-lookups).
+Then in the hiera data file for the role, e.g. `default.yaml`, we add the following three lookups.
+The data of the object with a single key named `value` are returned as a string.
+The multi-key object is returned as a Hash, and all fields, including `value`, must be accessed by explicitly using the key.
+Note that the certificate lookups also demonstrate access to the object keys requiring escaping because of the dots.
 
-`v2_guess_mount`: whether to try to guess mount for KV v2 (default `true`) - add `data` after your mount and disable to minimize amount of misses. See [Less lookups](#less-lookups).
+```yaml
+profile::vault_test::simple_string: "%{lookup('vault_simple_string')}"
+profile::vault_test::certificate_public: "%{lookup('\"vault_certificate_domain.net\".\"tls.crt\"')}"
+profile::vault_test::certificate_private: "%{lookup('\"vault_certificate_domain.net\".\"tls.key\"')}"
+profile::vault_test::certificate_default_value: "%{lookup('\"vault_certificate_domain.net\".value')}"
+```
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ The following are optional configuration parameters supported in the `options` h
 | `token`                  | The token to authenticate with Vault, also read as `ENV["VAULT_TOKEN"]` or a full path to the file with the token (eg. `/etc/vault_token.txt`). When bootstrapping, you can set this token as `IGNORE-VAULT` and the backend will be stubbed, which can be useful when bootstrapping.
 | `cache_for`              | How long to cache a given key in seconds. If not present the response will never be cached.
 | `confine_to_keys`        | Only use this backend if the key matches one of the regexes in the array, to avoid constantly reaching out to Vault for every parameter lookup
-| `continue_if_not_found`  | Allow hiera to look beyond vault if the value is not found
+| `continue_if_not_found`  | Allow hiera to look beyond vault if the value is not found (default: `false`)
 | `strip_from_keys`        | Patterns to strip from keys before lookup
 | `default_field`          | The default field within data to return. If not present, the lookup will be the full contents of the secret data.
-| `default_field_behavior` | seting to `ignore` or undefined will **always** retugn the value of `default_field` key from the object retrieved from Vault, even if other keys exist. If set to `only`, it **returns a single string if there's one and only one field named after `default_field` in Vault**, otherwise it returns a Hash of all found keys and values.
+| `default_field_behavior` | setting to `ignore` or undefined will **always** return the value of the `default_field`-named key from the object retrieved from Vault, even if other keys exist. If set to `only`, it **returns a single string if there's one and only one field named after `default_field` in Vault**, otherwise it returns a Hash of all found keys and values.
 | `default_field_parse`    | setting to `string` or undefined will parse the default field as string, `json` will parse it as JSON data
 | `mounts`                 | The list of mounts you want to do lookups against. This is treated as the backend hiearchy for lookup. It is recomended you use [Trusted Facts](https://puppet.com/docs/puppet/5.3/lang_facts_and_builtin_vars.html#trusted-facts) within the hierachy to ensure lookups are restricted to the correct hierachy points. See [Mounts](#mounts).
 | `ssl_verify`             | Specify whether to verify SSL certificates (default: `true`)
@@ -148,9 +148,9 @@ The following are optional configuration parameters supported in the `options` h
 | `ssl_ca_cert`            | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) configuration of the certificate authority
 | `ssl_ca_path`            | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) CA path
 | `ssl_ciphers`            | [vault-ruby's client](https://github.com/hashicorp/vault-ruby) configuration of TLS ciphers
-| `strict_mode`            | When enabled, the lookup function fail in case of http errors when looking up a secret.
-| `v1_lookup`              | whether to lookup within kv v1 hierarchy (default `true`) - disable if you only use kv v2 :) See [Less lookups](#less-lookups).
-| `v2_guess_mount`         | whether to try to guess mount for KV v2 (default `true`) - add `data` after your mount and disable to minimize amount of misses. See [Less lookups](#less-lookups).
+| `strict_mode`            | When enabled, the lookup function fails in case of http errors when looking up a secret.
+| `v1_lookup`              | whether to lookup within kv v1 hierarchy (default: `true`) - disable if you only use kv v2 :) See [Less lookups](#less-lookups).
+| `v2_guess_mount`         | whether to try to guess mount for KV v2 (default: `true`) - add `data` after your mount and disable this option to minimize amount of misses. See [Less lookups](#less-lookups).
 
 #### Example use of `confine_to_keys`
 

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -21,13 +21,13 @@ class Cache
   CacheValue = Struct.new(:value, :until)
 
   def initialize
-    @caches = Hash.new {|hash, key| hash[key] = {} }
+    @caches = Hash.new { |hash, key| hash[key] = {} }
   end
 
   def set(key, value, options)
     prune
 
-    cache_for = options['cache_for']
+    cache_for = options["cache_for"]
 
     # Early exit if the cache is deactivated
     return nil if cache_for.nil?
@@ -45,7 +45,7 @@ class Cache
   def get(key, options)
     prune
 
-    cache_for = options['cache_for']
+    cache_for = options["cache_for"]
 
     # Early exit if the cache is deactivated
     return nil if cache_for.nil?
@@ -76,33 +76,31 @@ class Cache
 end
 
 Puppet::Functions.create_function(:hiera_vault) do
-
   begin
-    require 'json'
+    require "json"
   rescue LoadError => e
     raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install json gem to use hiera-vault backend"
   end
   begin
-    require 'vault'
+    require "vault"
   rescue LoadError => e
     raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install vault gem to use hiera-vault backend"
   end
   begin
-    require 'debouncer'
+    require "debouncer"
   rescue LoadError => e
     raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install debouncer gem to use hiera-vault backend"
   end
   begin
-    require 'thread'
+    require "thread"
   rescue LoadError => e
     raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install thread gem to use hiera-vault backend"
   end
 
-
   dispatch :lookup_key do
-    param 'Variant[String, Numeric]', :key
-    param 'Hash', :options
-    param 'Puppet::LookupContext', :context
+    param "Variant[String, Numeric]", :key
+    param "Hash", :options
+    param "Puppet::LookupContext", :context
   end
 
   $cache = Cache.new
@@ -119,10 +117,10 @@ Puppet::Functions.create_function(:hiera_vault) do
   def vault_token(options)
     token = nil
 
-    token = ENV['VAULT_TOKEN'] unless ENV['VAULT_TOKEN'].nil?
-    token ||= options['token'] unless options['token'].nil?
+    token = ENV["VAULT_TOKEN"] unless ENV["VAULT_TOKEN"].nil?
+    token ||= options["token"] unless options["token"].nil?
 
-    if token.to_s.start_with?('/') and File.exist?(token)
+    if token.to_s.start_with?("/") and File.exist?(token)
       token = File.read(token).strip.chomp
     end
 
@@ -130,9 +128,8 @@ Puppet::Functions.create_function(:hiera_vault) do
   end
 
   def lookup_key(key, options, context)
-
-    if confine_keys = options['confine_to_keys']
-      raise ArgumentError, '[hiera-vault] confine_to_keys must be an array' unless confine_keys.is_a?(Array)
+    if confine_keys = options["confine_to_keys"]
+      raise ArgumentError, "[hiera-vault] confine_to_keys must be an array" unless confine_keys.is_a?(Array)
 
       begin
         confine_keys = confine_keys.map { |r| Regexp.new(r) }
@@ -148,27 +145,27 @@ Puppet::Functions.create_function(:hiera_vault) do
       end
     end
 
-    if strip_from_keys = options['strip_from_keys']
-      raise ArgumentError, '[hiera-vault] strip_from_keys must be an array' unless strip_from_keys.is_a?(Array)
+    if strip_from_keys = options["strip_from_keys"]
+      raise ArgumentError, "[hiera-vault] strip_from_keys must be an array" unless strip_from_keys.is_a?(Array)
 
       strip_from_keys.each do |prefix|
-        key = key.gsub(Regexp.new(prefix), '')
+        key = key.gsub(Regexp.new(prefix), "")
       end
     end
 
-    if vault_token(options) == 'IGNORE-VAULT'
+    if vault_token(options) == "IGNORE-VAULT"
       context.explain { "[hiera-vault] token set to IGNORE-VAULT - Quitting early" }
       return context.not_found
     end
 
     if vault_token(options).nil?
-      raise ArgumentError, '[hiera-vault] no token set in options and no token in VAULT_TOKEN'
+      raise ArgumentError, "[hiera-vault] no token set in options and no token in VAULT_TOKEN"
     end
 
     result = vault_get(key, options, context)
 
     # Allow hiera to look beyond vault if the value is not found
-    continue_if_not_found = options['continue_if_not_found'] || false
+    continue_if_not_found = options["continue_if_not_found"] || false
 
     if result.nil? and continue_if_not_found
       context.not_found
@@ -177,40 +174,37 @@ Puppet::Functions.create_function(:hiera_vault) do
     end
   end
 
-
   def vault_get(key, options, context)
-
-    if ! ['string','json',nil].include?(options['default_field_parse'])
-      raise ArgumentError, "[hiera-vault] invalid value for default_field_parse: '#{options['default_field_parse']}', should be one of 'string','json'"
+    if !["string", "json", nil].include?(options["default_field_parse"])
+      raise ArgumentError, "[hiera-vault] invalid value for default_field_parse: '#{options["default_field_parse"]}', should be one of 'string','json'"
     end
 
-    if ! ['ignore','only',nil].include?(options['default_field_behavior'])
-      raise ArgumentError, "[hiera-vault] invalid value for default_field_behavior: '#{options['default_field_behavior']}', should be one of 'ignore','only'"
+    if !["ignore", "only", nil].include?(options["default_field_behavior"])
+      raise ArgumentError, "[hiera-vault] invalid value for default_field_behavior: '#{options["default_field_behavior"]}', should be one of 'ignore','only'"
     end
 
-    if (! options['cache_for'].nil?) &&  (! options['cache_for'].is_a? Numeric)
-      raise ArgumentError, "[hiera-vault] invalid value for cache_for: '#{options['cache_for']}', should be a number or nil"
+    if (!options["cache_for"].nil?) && (!options["cache_for"].is_a? Numeric)
+      raise ArgumentError, "[hiera-vault] invalid value for cache_for: '#{options["cache_for"]}', should be a number or nil"
     end
 
     $hiera_vault_mutex.synchronize do
       cached_value = $cache.get(key, options)
-      return cached_value.value if ! cached_value.nil?
+      return cached_value.value if !cached_value.nil?
 
       # If our Vault client has got cleaned up by a previous shutdown call, reinstate it
       if $hiera_vault_client.nil?
         $hiera_vault_client = Vault::Client.new
       end
 
-
       begin
         $hiera_vault_client.configure do |config|
-          config.address = options['address'] unless options['address'].nil?
+          config.address = options["address"] unless options["address"].nil?
           config.token = vault_token(options)
-          config.ssl_pem_file = options['ssl_pem_file'] unless options['ssl_pem_file'].nil?
-          config.ssl_verify = options['ssl_verify'] unless options['ssl_verify'].nil?
-          config.ssl_ca_cert = options['ssl_ca_cert'] if config.respond_to? :ssl_ca_cert
-          config.ssl_ca_path = options['ssl_ca_path'] if config.respond_to? :ssl_ca_path
-          config.ssl_ciphers = options['ssl_ciphers'] if config.respond_to? :ssl_ciphers
+          config.ssl_pem_file = options["ssl_pem_file"] unless options["ssl_pem_file"].nil?
+          config.ssl_verify = options["ssl_verify"] unless options["ssl_verify"].nil?
+          config.ssl_ca_cert = options["ssl_ca_cert"] if config.respond_to? :ssl_ca_cert
+          config.ssl_ca_path = options["ssl_ca_path"] if config.respond_to? :ssl_ca_path
+          config.ssl_ciphers = options["ssl_ciphers"] if config.respond_to? :ssl_ciphers
         end
 
         if $hiera_vault_client.sys.seal_status.sealed?
@@ -225,12 +219,12 @@ Puppet::Functions.create_function(:hiera_vault) do
       end
 
       answer = nil
-      strict_mode = (options.key?('strict_mode') and options['strict_mode'])
+      strict_mode = (options.key?("strict_mode") and options["strict_mode"])
 
-      if options['mounts']['generic']
+      if options["mounts"]["generic"]
         raise ArgumentError, "[hiera-vault] generic is no longer valid - change to kv"
       else
-        kv_mounts = options['mounts'].dup
+        kv_mounts = options["mounts"].dup
       end
 
       # Only kv mounts supported so far
@@ -245,11 +239,11 @@ Puppet::Functions.create_function(:hiera_vault) do
           paths = []
 
           if options.fetch("v2_guess_mount", true)
-            paths << [:v2, File.join(mount, path, 'data', key).chomp('/')]
-            paths << [:v2, File.join(mount, 'data', path, key).chomp('/')]
+            paths << [:v2, File.join(mount, path, "data", key).chomp("/")]
+            paths << [:v2, File.join(mount, "data", path, key).chomp("/")]
           else
-            paths << [:v2, File.join(mount, path, key).chomp('/')]
-            paths << [:v2, File.join(mount, key).chomp('/')] if key.start_with?(path)
+            paths << [:v2, File.join(mount, path, key).chomp("/")]
+            paths << [:v2, File.join(mount, key).chomp("/")] if key.start_with?(path)
           end
 
           paths << [:v1, File.join(mount, path, key)] if options.fetch("v1_lookup", true)
@@ -275,25 +269,23 @@ Puppet::Functions.create_function(:hiera_vault) do
           next if secret.nil?
 
           context.explain { "[hiera-vault] Read secret: #{key}" }
-          if (options['default_field'] and ( ['ignore', nil].include?(options['default_field_behavior']) ||
-          (secret.has_key?(options['default_field'].to_sym) && secret.length == 1) ) )
-
-          if ! secret.has_key?(options['default_field'].to_sym)
-            $cache.set(key, nil, options)
-            return nil
-          end
-
-          new_answer = secret[options['default_field'].to_sym]
-
-          if options['default_field_parse'] == 'json'
-            begin
-              new_answer = JSON.parse(new_answer, :quirks_mode => true)
-            rescue JSON::ParserError => e
-              context.explain { "[hiera-vault] Could not parse string as json: #{e}" }
+          if (options["default_field"] and (["ignore", nil].include?(options["default_field_behavior"]) ||
+                                            (secret.has_key?(options["default_field"].to_sym) && secret.length == 1)))
+            if !secret.has_key?(options["default_field"].to_sym)
+              $cache.set(key, nil, options)
+              return nil
             end
-          end
 
-        else
+            new_answer = secret[options["default_field"].to_sym]
+
+            if options["default_field_parse"] == "json"
+              begin
+                new_answer = JSON.parse(new_answer, :quirks_mode => true)
+              rescue JSON::ParserError => e
+                context.explain { "[hiera-vault] Could not parse string as json: #{e}" }
+              end
+            end
+          else
             # Turn secret's hash keys into strings allow for nested arrays and hashes
             # this enables support for create resources etc
             new_answer = secret.inject({}) { |h, (k, v)| h[k.to_s] = stringify_keys v; h }
@@ -340,7 +332,7 @@ Puppet::Functions.create_function(:hiera_vault) do
       path = context.interpolate(path)
       # TODO: Unify usage of '/' - File.join seems to be a mistake, since it won't work on Windows
       # secret/puppet/scope1,scope2 => [[secret], [puppet], [scope1, scope2]]
-      segments = path.split('/').map { |segment| segment.split(',') }
+      segments = path.split("/").map { |segment| segment.split(",") }
       allowed_paths += build_paths(segments) unless segments.empty?
     end
     allowed_paths


### PR DESCRIPTION
This change reformats the Ruby code using [rufo](https://github.com/ruby-formatter/rufo). The updated code is slightly easier to read especially in the (formerly misaligned) conditional code handling the `default_field_behavior` option.

This change also documents multiple undocumented options, adds an example of how to access a multi-key Vault object's data, mentions OpenBao as an alternative to Vault, and fixes some dead(ish) links.