### PR TITLE
Update path interpolate function to allow root

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -313,6 +313,10 @@ Puppet::Functions.create_function(:hiera_vault) do
     allowed_paths = []
     paths.each do |path|
       path = context.interpolate(path)
+      if path == '/'
+        allowed_paths += ['/']
+        next
+      end
       # TODO: Unify usage of '/' - File.join seems to be a mistake, since it won't work on Windows
       # secret/puppet/scope1,scope2 => [[secret], [puppet], [scope1, scope2]]
       segments = path.split('/').map { |segment| segment.split(',') }

--- a/spec/functions/hiera_vault_path_interpolation_spec.rb
+++ b/spec/functions/hiera_vault_path_interpolation_spec.rb
@@ -35,6 +35,7 @@ describe FakeFunction do
       'v1_lookup' => false,
       'mounts' => {
         VAULT_PATH + '/data' => [
+          '/',
           'common',
           'rproxy,api'
         ]
@@ -58,6 +59,7 @@ describe FakeFunction do
           vault_test_client.kv(VAULT_PATH).write('rproxy/ssl', { value: 'ssl' })
           vault_test_client.kv(VAULT_PATH).write('api/oauth', { value: 'oauth' })
           vault_test_client.kv(VAULT_PATH).write('api', { value: 'api_specific' })
+          vault_test_client.kv(VAULT_PATH).write('explicit/path', { value: 'just-a-value' })
         end
 
         context 'reading secrets' do
@@ -79,6 +81,11 @@ describe FakeFunction do
           it 'returns key from second option with full path to node' do
             expect(function.lookup_key('api/oauth', vault_options, context)).
               to include('value' => 'oauth')
+          end
+
+          it 'returns key from explicit lookup' do
+            expect(function.lookup_key('explicit/path', vault_options, context)).
+              to include('value' => 'just-a-value')
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description

The issue with the current `interpolate` function: it **silently drops the root path (`/`)**. This happens because `split('/')` on `/` returns an empty array (`[]`), which is then skipped due to the `unless segments.empty?` condition.

For our use case, the root path (`/`) is a **valid and meaningful entry**. It allows us to use explicit lookups in hieradata, which brings several benefits:

- **Reduced traversal** through the vault tree.
- **Improved readability** of configurations.
- **More flexibility** in how we structure and migrate secrets.

For example, with a path list like:

- `/`
- `nodes/%{facts.networking.fqdn}`
- `environments/%{trusted.extensions.pp_role}`
- `common`

We can resolve secrets like this in `common.yaml`:

```yaml
profile::cool::access_key: "%{lookup('provider/s3/access-keys/fancy-prd.key')}"
```
This would map to the vault path `/provider/s3/access-keys/fancy-prd.key`.

We’re migrating all our secrets to explicit lookups, and this path list allows us to do it **gradually**, rather than in a big-bang migration. However, the current implementation makes this difficult.